### PR TITLE
Add shared page and card section layouts

### DIFF
--- a/esbok-client/app/activities/page.tsx
+++ b/esbok-client/app/activities/page.tsx
@@ -1,13 +1,13 @@
-import BottomNav from "@/components/bottom-nav";
 import { activityFeed, myFoodItems } from "@/lib/data";
 import { Activity, Heart, Apple, MapPin, Clock, Plus } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import PageLayout from "@/components/page-layout";
+import CardSectionsLayout from "@/components/card-sections-layout";
 
 export default function ActivitiesPage() {
   return (
-    <div className="max-w-sm mx-auto bg-white min-h-screen flex flex-col">
-      <div className="flex-1 overflow-y-auto pb-20 space-y-6">
+    <PageLayout contentClassName="space-y-6">
         <div className="px-5 pt-6">
           <h1 className="text-2xl font-bold text-gray-800 mb-2">Community Activity</h1>
           <p className="text-sm text-gray-600">See what&apos;s happening in your community</p>
@@ -43,8 +43,7 @@ export default function ActivitiesPage() {
             </Card>
           </div>
         </div>
-        <div className="px-5">
-          <h2 className="text-lg font-bold text-gray-800 mb-4">My Food</h2>
+        <CardSectionsLayout title="My Food">
           <div className="space-y-3">
             {myFoodItems.map((food) => (
               <Card key={food.id} className="border border-esbok-border relative">
@@ -77,9 +76,8 @@ export default function ActivitiesPage() {
               </Card>
             ))}
           </div>
-        </div>
-        <div className="px-5 pb-6">
-          <h2 className="text-lg font-bold text-gray-800 mb-4">Recent Activity</h2>
+        </CardSectionsLayout>
+        <CardSectionsLayout title="Recent Activity" className="pb-6">
           <div className="space-y-4">
             {activityFeed.map((activity) => (
               <Card key={activity.id} className="border border-esbok-border">
@@ -111,9 +109,7 @@ export default function ActivitiesPage() {
               </Card>
             ))}
           </div>
-        </div>
-      </div>
-      <BottomNav />
-    </div>
+        </CardSectionsLayout>
+    </PageLayout>
   );
 }

--- a/esbok-client/app/home/page.tsx
+++ b/esbok-client/app/home/page.tsx
@@ -1,13 +1,13 @@
-import BottomNav from "@/components/bottom-nav";
 import { pantryItems } from "@/lib/data";
 import { Apple, Users, Heart, Clock, MapPin } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import PageLayout from "@/components/page-layout";
+import CardSectionsLayout from "@/components/card-sections-layout";
 
 export default function HomePage() {
   return (
-    <div className="max-w-sm mx-auto bg-white min-h-screen flex flex-col">
-      <div className="flex-1 overflow-y-auto pb-20 space-y-5">
+    <PageLayout contentClassName="space-y-5">
         {/* Header */}
         <div className="text-center py-6">
           <h1 className="text-2xl font-bold text-gray-800 mb-2">Welcome to Esbok</h1>
@@ -46,8 +46,7 @@ export default function HomePage() {
         </div>
 
         {/* Recent Activity */}
-        <div className="px-5">
-          <h2 className="text-lg font-bold text-gray-800 mb-4">Recent Activity</h2>
+        <CardSectionsLayout title="Recent Activity">
           <div className="space-y-4">
             {pantryItems.map((item) => (
               <Card key={item.id} className="border border-esbok-border">
@@ -81,9 +80,7 @@ export default function HomePage() {
               </Card>
             ))}
           </div>
-        </div>
-      </div>
-      <BottomNav />
-    </div>
+        </CardSectionsLayout>
+    </PageLayout>
   );
 }

--- a/esbok-client/app/nearby/page.tsx
+++ b/esbok-client/app/nearby/page.tsx
@@ -1,13 +1,13 @@
-import BottomNav from "@/components/bottom-nav";
 import { nearbyPantries } from "@/lib/data";
 import { MapPin, Apple, Plus } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import PageLayout from "@/components/page-layout";
+import CardSectionsLayout from "@/components/card-sections-layout";
 
 export default function NearbyPage() {
   return (
-    <div className="max-w-sm mx-auto bg-white min-h-screen flex flex-col">
-      <div className="flex-1 overflow-y-auto pb-20 flex flex-col h-full">
+    <PageLayout contentClassName="flex flex-col h-full">
         {/* Map Section */}
         <div className="relative w-full h-64 bg-gray-100 border-b border-esbok-border">
           <div className="absolute inset-0 bg-gray-100 flex items-center justify-center">
@@ -64,8 +64,7 @@ export default function NearbyPage() {
           </Button>
         </div>
         <div className="flex-1 overflow-y-auto">
-          <div className="px-5 py-4">
-            <h2 className="text-lg font-bold text-gray-800 mb-4">Nearby Pantries</h2>
+          <CardSectionsLayout title="Nearby Pantries" className="py-4">
             <div className="space-y-3">
               {nearbyPantries.map((pantry) => (
                 <Card key={pantry.id} className="border border-esbok-border overflow-hidden">
@@ -97,10 +96,8 @@ export default function NearbyPage() {
                 </Card>
               ))}
             </div>
-          </div>
+          </CardSectionsLayout>
         </div>
-      </div>
-      <BottomNav />
-    </div>
+    </PageLayout>
   );
 }

--- a/esbok-client/app/pantries/page.tsx
+++ b/esbok-client/app/pantries/page.tsx
@@ -1,19 +1,19 @@
 'use client'
 import { useState } from 'react';
-import BottomNav from '@/components/bottom-nav';
 import { allPantries, recentlyViewedPantries } from '@/lib/data';
 import { Apple, Plus, MapPin, Heart, Clock } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import PageLayout from '@/components/page-layout';
+import CardSectionsLayout from '@/components/card-sections-layout';
 
 export default function PantriesPage() {
   const [pantryFilter, setPantryFilter] = useState('admin');
   const filteredPantries = allPantries.filter((p) => p.status === pantryFilter);
 
   return (
-    <div className="max-w-sm mx-auto bg-white min-h-screen flex flex-col">
-      <div className="flex-1 overflow-y-auto pb-20 space-y-6">
+    <PageLayout contentClassName="space-y-6">
         <div className="px-5 pt-6">
           <h1 className="text-2xl font-bold text-gray-800 mb-2">My Pantries</h1>
           <p className="text-sm text-gray-600">Manage and contribute to your pantries</p>
@@ -52,7 +52,7 @@ export default function PantriesPage() {
             </Button>
           </div>
         </div>
-        <div className="px-5 pb-6">
+        <CardSectionsLayout className="pb-6">
           <div className="space-y-3">
             {filteredPantries
               .sort((a, b) => (b.isFavorite ? 1 : 0) - (a.isFavorite ? 1 : 0))
@@ -118,10 +118,9 @@ export default function PantriesPage() {
               <p className="text-gray-500 text-sm">No {pantryFilter} pantries found</p>
             </div>
           )}
-        </div>
+        </CardSectionsLayout>
         {pantryFilter === 'admin' && (
-          <div className="px-5 pb-6">
-            <h2 className="text-lg font-bold text-gray-800 mb-4">Recently Viewed</h2>
+          <CardSectionsLayout title="Recently Viewed" className="pb-6">
             <div className="space-y-3">
               {recentlyViewedPantries.map((pantry) => (
                 <Card key={pantry.id} className="border border-esbok-border overflow-hidden">
@@ -152,10 +151,8 @@ export default function PantriesPage() {
                 </Card>
               ))}
             </div>
-          </div>
+          </CardSectionsLayout>
         )}
-      </div>
-      <BottomNav />
-    </div>
+    </PageLayout>
   );
 }

--- a/esbok-client/components/card-sections-layout.tsx
+++ b/esbok-client/components/card-sections-layout.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface CardSectionsLayoutProps {
+  /** Optional title to display above the section. */
+  title?: string;
+  children: React.ReactNode;
+  /** Extra classes applied to the outer section element. */
+  className?: string;
+  /** Extra classes applied to the title element. */
+  titleClassName?: string;
+}
+
+export default function CardSectionsLayout({
+  title,
+  children,
+  className,
+  titleClassName,
+}: CardSectionsLayoutProps) {
+  return (
+    <section className={cn("px-5", className)}>
+      {title && (
+        <h2 className={cn("text-lg font-bold text-gray-800 mb-4", titleClassName)}>
+          {title}
+        </h2>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/esbok-client/components/page-layout.tsx
+++ b/esbok-client/components/page-layout.tsx
@@ -1,0 +1,30 @@
+import BottomNav from "@/components/bottom-nav";
+import { cn } from "@/lib/utils";
+import React from "react";
+
+interface PageLayoutProps {
+  children: React.ReactNode;
+  /**
+   * Extra classes for the scrollable content container.
+   */
+  contentClassName?: string;
+  /**
+   * Show the bottom navigation bar. Defaults to true.
+   */
+  withBottomNav?: boolean;
+}
+
+export default function PageLayout({
+  children,
+  contentClassName,
+  withBottomNav = true,
+}: PageLayoutProps) {
+  return (
+    <div className="max-w-sm mx-auto bg-white min-h-screen flex flex-col">
+      <div className={cn("flex-1 overflow-y-auto", withBottomNav && "pb-20", contentClassName)}>
+        {children}
+      </div>
+      {withBottomNav && <BottomNav />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `PageLayout` for consistent mobile page wrappers
- add `CardSectionsLayout` for repeated card section formatting
- refactor Home, Activities, Nearby, and Pantries pages to use new layouts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843c89fba188321a97f37a07b0bd726