### PR TITLE
Hide bottom nav on desktop

### DIFF
--- a/esbok-client/app/profile/page.tsx
+++ b/esbok-client/app/profile/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 export default function ProfilePage() {
   return (
     <div className="max-w-sm mx-auto bg-white min-h-screen flex flex-col">
-      <div className="flex-1 overflow-y-auto pb-20">
+      <div className="flex-1 overflow-y-auto pb-20 md:pb-0">
         <div className="flex flex-col items-center text-center p-6 space-y-3">
           <div className="w-24 h-24 rounded-full overflow-hidden bg-gray-100">
             <img

--- a/esbok-client/components/bottom-nav.tsx
+++ b/esbok-client/components/bottom-nav.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 export default function BottomNav() {
   const pathname = usePathname();
   return (
-    <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-sm bg-white border-t border-esbok-border">
+    <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-sm bg-white border-t border-esbok-border md:hidden">
       <div className="flex items-center justify-around py-2 px-4">
         <Button
           asChild

--- a/esbok-client/components/page-layout.tsx
+++ b/esbok-client/components/page-layout.tsx
@@ -21,7 +21,13 @@ export default function PageLayout({
 }: PageLayoutProps) {
   return (
     <div className="max-w-sm mx-auto bg-white min-h-screen flex flex-col">
-      <div className={cn("flex-1 overflow-y-auto", withBottomNav && "pb-20", contentClassName)}>
+      <div
+        className={cn(
+          "flex-1 overflow-y-auto",
+          withBottomNav && "pb-20 md:pb-0",
+          contentClassName
+        )}
+      >
         {children}
       </div>
       {withBottomNav && <BottomNav />}


### PR DESCRIPTION
## Summary
- hide bottom nav on md screens
- adjust page layout to remove bottom padding when nav is hidden
- update profile page to match responsive padding

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843d2af8a4883218316e6861c2c5970