### PR TITLE
Create composite card components

### DIFF
--- a/esbok-client/app/activities/page.tsx
+++ b/esbok-client/app/activities/page.tsx
@@ -1,6 +1,5 @@
 import { activityFeed, myFoodItems } from "@/lib/data";
 import { Activity, Heart, Apple, MapPin, Clock, Plus } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import PageLayout from "@/components/page-layout";
 import CardSectionsLayout from "@/components/card-sections-layout";

--- a/esbok-client/app/activities/page.tsx
+++ b/esbok-client/app/activities/page.tsx
@@ -4,6 +4,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import PageLayout from "@/components/page-layout";
 import CardSectionsLayout from "@/components/card-sections-layout";
+import StatCard from "@/components/composite/stat-card";
+import MediaCard from "@/components/composite/media-card";
 
 export default function ActivitiesPage() {
   return (
@@ -14,99 +16,104 @@ export default function ActivitiesPage() {
         </div>
         <div className="px-5">
           <div className="grid grid-cols-3 gap-3">
-            <Card className="border border-esbok-border">
-              <CardContent className="p-3 text-center">
-                <div className="w-6 h-6 mx-auto mb-1 rounded-full bg-esbok-mint flex items-center justify-center">
-                  <Activity className="w-3 h-3 text-gray-700" />
-                </div>
-                <p className="text-xs text-gray-600">Today&apos;s Activity</p>
-                <p className="text-lg font-bold text-gray-800">12</p>
-              </CardContent>
-            </Card>
-            <Card className="border border-esbok-border">
-              <CardContent className="p-3 text-center">
-                <div className="w-6 h-6 mx-auto mb-1 rounded-full bg-esbok-peach flex items-center justify-center">
-                  <Heart className="w-3 h-3 text-gray-700" />
-                </div>
-                <p className="text-xs text-gray-600">Thanks Received</p>
-                <p className="text-lg font-bold text-gray-800">8</p>
-              </CardContent>
-            </Card>
-            <Card className="border border-esbok-border">
-              <CardContent className="p-3 text-center">
-                <div className="w-6 h-6 mx-auto mb-1 rounded-full bg-esbok-primary flex items-center justify-center">
-                  <Apple className="w-3 h-3 text-gray-700" />
-                </div>
-                <p className="text-xs text-gray-600">Total Foods</p>
-                <p className="text-lg font-bold text-gray-800">24</p>
-              </CardContent>
-            </Card>
+            <StatCard
+              icon={<Activity className="text-gray-700" />}
+              label="Today's Activity"
+              value="12"
+              iconBgClass="bg-esbok-mint"
+              size="sm"
+            />
+            <StatCard
+              icon={<Heart className="text-gray-700" />}
+              label="Thanks Received"
+              value="8"
+              iconBgClass="bg-esbok-peach"
+              size="sm"
+            />
+            <StatCard
+              icon={<Apple className="text-gray-700" />}
+              label="Total Foods"
+              value="24"
+              iconBgClass="bg-esbok-primary"
+              size="sm"
+            />
           </div>
         </div>
         <CardSectionsLayout title="My Food">
           <div className="space-y-3">
             {myFoodItems.map((food) => (
-              <Card key={food.id} className="border border-esbok-border relative">
-                <CardContent className="p-4">
-                  {food.expiresInDays <= 3 && (
-                    <div className="absolute top-3 left-3">
-                      <Badge className="text-xs bg-red-100 text-red-700 border-red-200">Expires Soon</Badge>
-                    </div>
-                  )}
-                  <div className="flex gap-3">
-                    <div className="w-16 h-16 bg-gray-100 rounded-lg flex-shrink-0 flex items-center justify-center">
-                      <Apple className="w-8 h-8 text-gray-400" />
-                    </div>
-                    <div className="flex-1 min-w-0 pt-2">
-                      <div className="flex items-start justify-between mb-1">
-                        <h3 className="font-semibold text-sm text-gray-800 truncate">{food.name}</h3>
-                        <Badge variant="secondary" className={`ml-2 text-xs ${food.isShared ? 'bg-esbok-mint text-gray-700' : 'bg-gray-100 text-gray-600'}`}>{food.isShared ? 'Shared' : 'Private'}</Badge>
-                      </div>
-                      <div className="flex items-center gap-2 text-xs text-gray-500 mb-1">
-                        <MapPin className="w-3 h-3" />
-                        <span className="truncate">{food.pantry}</span>
-                      </div>
-                      <div className="flex items-center gap-1 text-xs text-gray-500">
-                        <Clock className="w-3 h-3" />
-                        <span>{food.daysOld} {food.daysOld === 1 ? 'day' : 'days'} old</span>
-                      </div>
-                    </div>
+              <MediaCard
+                key={food.id}
+                className="relative"
+                left={
+                  <div className="w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center">
+                    <Apple className="w-8 h-8 text-gray-400" />
                   </div>
-                </CardContent>
-              </Card>
+                }
+              >
+                {food.expiresInDays <= 3 && (
+                  <div className="absolute top-3 left-3">
+                    <Badge className="text-xs bg-red-100 text-red-700 border-red-200">Expires Soon</Badge>
+                  </div>
+                )}
+                <div className="pt-2">
+                  <div className="flex items-start justify-between mb-1">
+                    <h3 className="font-semibold text-sm text-gray-800 truncate">{food.name}</h3>
+                    <Badge variant="secondary" className={`ml-2 text-xs ${food.isShared ? 'bg-esbok-mint text-gray-700' : 'bg-gray-100 text-gray-600'}`}>{food.isShared ? 'Shared' : 'Private'}</Badge>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-gray-500 mb-1">
+                    <MapPin className="w-3 h-3" />
+                    <span className="truncate">{food.pantry}</span>
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-gray-500">
+                    <Clock className="w-3 h-3" />
+                    <span>{food.daysOld} {food.daysOld === 1 ? 'day' : 'days'} old</span>
+                  </div>
+                </div>
+              </MediaCard>
             ))}
           </div>
         </CardSectionsLayout>
         <CardSectionsLayout title="Recent Activity" className="pb-6">
           <div className="space-y-4">
             {activityFeed.map((activity) => (
-              <Card key={activity.id} className="border border-esbok-border">
-                <CardContent className="p-4">
-                  <div className="flex gap-3">
-                    <div className="flex-shrink-0">
-                      <div className={`w-8 h-8 rounded-full flex items-center justify-center ${activity.type === 'contribution' ? 'bg-esbok-mint' : activity.type === 'consumption' || activity.type === 'thanks' ? 'bg-esbok-pink' : activity.type === 'new_pantry' ? 'bg-esbok-primary' : activity.type === 'milestone' ? 'bg-esbok-peach' : 'bg-gray-200'}`}> 
-                        {activity.icon === 'plus' && <Plus className="w-4 h-4 text-gray-700" />}
-                        {activity.icon === 'heart' && <Heart className="w-4 h-4 text-gray-700" />}
-                        {activity.icon === 'star' && (
-                          <svg className="w-4 h-4 text-gray-700" fill="currentColor" viewBox="0 0 20 20">
-                            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                          </svg>
-                        )}
-                        {activity.icon === 'clock' && <Clock className="w-4 h-4 text-gray-700" />}
-                      </div>
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm text-gray-800">
-                        <span className="font-semibold">{activity.user}</span> <span>{activity.action}</span>
-                        {activity.pantry && (
-                          <span className="font-semibold text-esbok-primary"> {activity.pantry}</span>
-                        )}
-                      </div>
-                      <p className="text-xs text-gray-500 mt-1">{activity.timeAgo}</p>
-                    </div>
+              <MediaCard
+                key={activity.id}
+                left={
+                  <div
+                    className={`w-8 h-8 rounded-full flex items-center justify-center ${
+                      activity.type === 'contribution'
+                        ? 'bg-esbok-mint'
+                        : activity.type === 'consumption' || activity.type === 'thanks'
+                        ? 'bg-esbok-pink'
+                        : activity.type === 'new_pantry'
+                        ? 'bg-esbok-primary'
+                        : activity.type === 'milestone'
+                        ? 'bg-esbok-peach'
+                        : 'bg-gray-200'
+                    }`}
+                  >
+                    {activity.icon === 'plus' && <Plus className="w-4 h-4 text-gray-700" />}
+                    {activity.icon === 'heart' && <Heart className="w-4 h-4 text-gray-700" />}
+                    {activity.icon === 'star' && (
+                      <svg className="w-4 h-4 text-gray-700" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                      </svg>
+                    )}
+                    {activity.icon === 'clock' && <Clock className="w-4 h-4 text-gray-700" />}
                   </div>
-                </CardContent>
-              </Card>
+                }
+              >
+                <div>
+                  <div className="text-sm text-gray-800">
+                    <span className="font-semibold">{activity.user}</span> <span>{activity.action}</span>
+                    {activity.pantry && (
+                      <span className="font-semibold text-esbok-primary"> {activity.pantry}</span>
+                    )}
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1">{activity.timeAgo}</p>
+                </div>
+              </MediaCard>
             ))}
           </div>
         </CardSectionsLayout>

--- a/esbok-client/app/home/page.tsx
+++ b/esbok-client/app/home/page.tsx
@@ -1,6 +1,5 @@
 import { pantryItems } from "@/lib/data";
 import { Apple, Users, Heart, Clock, MapPin } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import PageLayout from "@/components/page-layout";
 import CardSectionsLayout from "@/components/card-sections-layout";

--- a/esbok-client/app/home/page.tsx
+++ b/esbok-client/app/home/page.tsx
@@ -4,6 +4,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import PageLayout from "@/components/page-layout";
 import CardSectionsLayout from "@/components/card-sections-layout";
+import StatCard from "@/components/composite/stat-card";
+import MediaCard from "@/components/composite/media-card";
 
 export default function HomePage() {
   return (
@@ -16,68 +18,59 @@ export default function HomePage() {
 
         {/* Quick Stats */}
         <div className="grid grid-cols-3 gap-4 px-5">
-          <Card className="border border-esbok-border">
-            <CardContent className="p-4 text-center">
-              <div className="w-8 h-8 mx-auto mb-2 rounded-full bg-esbok-mint flex items-center justify-center">
-                <Apple className="w-4 h-4 text-gray-700" />
-              </div>
-              <p className="text-xs text-gray-600">Items Shared</p>
-              <p className="text-lg font-bold text-gray-800">24</p>
-            </CardContent>
-          </Card>
-          <Card className="border border-esbok-border">
-            <CardContent className="p-4 text-center">
-              <div className="w-8 h-8 mx-auto mb-2 rounded-full bg-esbok-peach flex items-center justify-center">
-                <Users className="w-4 h-4 text-gray-700" />
-              </div>
-              <p className="text-xs text-gray-600">Community</p>
-              <p className="text-lg font-bold text-gray-800">156</p>
-            </CardContent>
-          </Card>
-          <Card className="border border-esbok-border">
-            <CardContent className="p-4 text-center">
-              <div className="w-8 h-8 mx-auto mb-2 rounded-full bg-esbok-pink flex items-center justify-center">
-                <Heart className="w-4 h-4 text-gray-700" />
-              </div>
-              <p className="text-xs text-gray-600">Likes Given</p>
-              <p className="text-lg font-bold text-gray-800">89</p>
-            </CardContent>
-          </Card>
+          <StatCard
+            icon={<Apple className="text-gray-700" />}
+            label="Items Shared"
+            value="24"
+            iconBgClass="bg-esbok-mint"
+          />
+          <StatCard
+            icon={<Users className="text-gray-700" />}
+            label="Community"
+            value="156"
+            iconBgClass="bg-esbok-peach"
+          />
+          <StatCard
+            icon={<Heart className="text-gray-700" />}
+            label="Likes Given"
+            value="89"
+            iconBgClass="bg-esbok-pink"
+          />
         </div>
 
         {/* Recent Activity */}
         <CardSectionsLayout title="Recent Activity">
           <div className="space-y-4">
             {pantryItems.map((item) => (
-              <Card key={item.id} className="border border-esbok-border">
-                <CardContent className="p-4">
-                  <div className="flex gap-3">
-                    <div className="w-16 h-16 bg-gray-100 rounded-lg flex-shrink-0 flex items-center justify-center">
-                      <Apple className="w-8 h-8 text-gray-400" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-start justify-between mb-1">
-                        <h3 className="font-semibold text-sm text-gray-800 truncate">{item.name}</h3>
-                        <Badge variant="secondary" className="ml-2 text-xs bg-esbok-mint text-gray-700">
-                          {item.category}
-                        </Badge>
-                      </div>
-                      <p className="text-xs text-gray-600 mb-1">by {item.contributor}</p>
-                      <div className="flex items-center gap-2 text-xs text-gray-500">
-                        <Clock className="w-3 h-3" />
-                        <span>{item.timeAgo}</span>
-                        <span>•</span>
-                        <MapPin className="w-3 h-3" />
-                        <span className="truncate">{item.location}</span>
-                      </div>
-                      <div className="flex items-center gap-1 mt-2">
-                        <Heart className="w-3 h-3 text-esbok-pink" />
-                        <span className="text-xs text-gray-600">{item.likes}</span>
-                      </div>
-                    </div>
+              <MediaCard
+                key={item.id}
+                left={
+                  <div className="w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center">
+                    <Apple className="w-8 h-8 text-gray-400" />
                   </div>
-                </CardContent>
-              </Card>
+                }
+              >
+                <div>
+                  <div className="flex items-start justify-between mb-1">
+                    <h3 className="font-semibold text-sm text-gray-800 truncate">{item.name}</h3>
+                    <Badge variant="secondary" className="ml-2 text-xs bg-esbok-mint text-gray-700">
+                      {item.category}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-gray-600 mb-1">by {item.contributor}</p>
+                  <div className="flex items-center gap-2 text-xs text-gray-500">
+                    <Clock className="w-3 h-3" />
+                    <span>{item.timeAgo}</span>
+                    <span>•</span>
+                    <MapPin className="w-3 h-3" />
+                    <span className="truncate">{item.location}</span>
+                  </div>
+                  <div className="flex items-center gap-1 mt-2">
+                    <Heart className="w-3 h-3 text-esbok-pink" />
+                    <span className="text-xs text-gray-600">{item.likes}</span>
+                  </div>
+                </div>
+              </MediaCard>
             ))}
           </div>
         </CardSectionsLayout>

--- a/esbok-client/app/nearby/page.tsx
+++ b/esbok-client/app/nearby/page.tsx
@@ -1,6 +1,5 @@
 import { nearbyPantries } from "@/lib/data";
 import { MapPin, Apple, Plus } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import PageLayout from "@/components/page-layout";
 import CardSectionsLayout from "@/components/card-sections-layout";

--- a/esbok-client/app/nearby/page.tsx
+++ b/esbok-client/app/nearby/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import PageLayout from "@/components/page-layout";
 import CardSectionsLayout from "@/components/card-sections-layout";
+import MediaCard from "@/components/composite/media-card";
 
 export default function NearbyPage() {
   return (
@@ -67,33 +68,35 @@ export default function NearbyPage() {
           <CardSectionsLayout title="Nearby Pantries" className="py-4">
             <div className="space-y-3">
               {nearbyPantries.map((pantry) => (
-                <Card key={pantry.id} className="border border-esbok-border overflow-hidden">
-                  <CardContent className="p-0">
-                    <div className="flex">
-                      <div className="w-20 h-20 bg-gray-100 flex-shrink-0 flex items-center justify-center">
-                        <img src={pantry.image || "/placeholder.svg"} alt={pantry.name} className="w-full h-full object-cover" />
-                      </div>
-                      <div className="flex-1 p-3">
-                        <h3 className="font-semibold text-sm text-gray-800 mb-1">{pantry.name}</h3>
-                        <div className="flex items-center gap-1 text-xs text-gray-500 mb-1">
-                          <MapPin className="w-3 h-3" />
-                          <span>{pantry.distance}</span>
-                        </div>
-                        <div className="flex items-center gap-1 text-xs text-gray-500">
-                          <Apple className="w-3 h-3" />
-                          <span>{pantry.itemCount} items available</span>
-                        </div>
-                      </div>
-                      <div className="flex items-center pr-3">
-                        <div className="text-gray-400">
-                          <svg width="6" height="10" viewBox="0 0 6 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M1 9L5 5L1 1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                          </svg>
-                        </div>
-                      </div>
+                <MediaCard
+                  key={pantry.id}
+                  className="overflow-hidden"
+                  contentClassName="p-0"
+                  left={
+                    <div className="w-20 h-20 bg-gray-100 flex items-center justify-center">
+                      <img src={pantry.image || "/placeholder.svg"} alt={pantry.name} className="w-full h-full object-cover" />
                     </div>
-                  </CardContent>
-                </Card>
+                  }
+                  right={
+                    <div className="text-gray-400">
+                      <svg width="6" height="10" viewBox="0 0 6 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M1 9L5 5L1 1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </div>
+                  }
+                >
+                  <div className="p-3">
+                    <h3 className="font-semibold text-sm text-gray-800 mb-1">{pantry.name}</h3>
+                    <div className="flex items-center gap-1 text-xs text-gray-500 mb-1">
+                      <MapPin className="w-3 h-3" />
+                      <span>{pantry.distance}</span>
+                    </div>
+                    <div className="flex items-center gap-1 text-xs text-gray-500">
+                      <Apple className="w-3 h-3" />
+                      <span>{pantry.itemCount} items available</span>
+                    </div>
+                  </div>
+                </MediaCard>
               ))}
             </div>
           </CardSectionsLayout>

--- a/esbok-client/app/pantries/page.tsx
+++ b/esbok-client/app/pantries/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import PageLayout from '@/components/page-layout';
 import CardSectionsLayout from '@/components/card-sections-layout';
+import MediaCard from '@/components/composite/media-card';
 
 export default function PantriesPage() {
   const [pantryFilter, setPantryFilter] = useState('admin');
@@ -57,59 +58,61 @@ export default function PantriesPage() {
             {filteredPantries
               .sort((a, b) => (b.isFavorite ? 1 : 0) - (a.isFavorite ? 1 : 0))
               .map((pantry) => (
-                <Card key={pantry.id} className="border border-esbok-border overflow-hidden">
-                  <CardContent className="p-0">
-                    <div className="flex">
-                      <div className="w-20 h-20 bg-gray-100 flex-shrink-0 flex items-center justify-center relative">
-                        <img src={pantry.image || '/placeholder.svg'} alt={pantry.name} className="w-full h-full object-cover" />
-                        {pantry.isFavorite && (
-                          <div className="absolute top-1 right-1">
-                            <Heart className="w-3 h-3 fill-esbok-pink text-esbok-pink" />
-                          </div>
-                        )}
-                      </div>
-                      <div className="flex-1 p-3">
-                        <div className="flex items-start justify-between mb-1">
-                          <h3 className="font-semibold text-sm text-gray-800">{pantry.name}</h3>
-                          {pantry.status === 'admin' && (
-                            <Badge variant='secondary' className="text-xs bg-esbok-mint text-gray-700">Admin</Badge>
-                          )}
-                          {pantry.status === 'joined' && (
-                            <Badge variant='secondary' className="text-xs bg-purple-100 text-purple-700">Joined</Badge>
-                          )}
+                <MediaCard
+                  key={pantry.id}
+                  className="overflow-hidden"
+                  contentClassName="p-0"
+                  left={
+                    <div className="w-20 h-20 bg-gray-100 flex items-center justify-center relative">
+                      <img src={pantry.image || '/placeholder.svg'} alt={pantry.name} className="w-full h-full object-cover" />
+                      {pantry.isFavorite && (
+                        <div className="absolute top-1 right-1">
+                          <Heart className="w-3 h-3 fill-esbok-pink text-esbok-pink" />
                         </div>
-                        <div className="flex items-center gap-1 text-xs text-gray-500 mb-1">
-                          <Apple className="w-3 h-3" />
-                          <span>{pantry.itemCount} items</span>
-                          {pantry.distance && (
-                            <>
-                              <span>•</span>
-                              <MapPin className="w-3 h-3" />
-                              <span>{pantry.distance}</span>
-                            </>
-                          )}
-                        </div>
-                        {pantry.lastContributed && (
-                          <div className="flex items-center gap-1 text-xs text-gray-500">
-                            <Clock className="w-3 h-3" />
-                            <span>Last contributed {pantry.lastContributed}</span>
-                          </div>
-                        )}
-                      </div>
-                      <div className="flex items-center pr-3">
-                        {pantry.status === 'nearby' ? (
-                          <Button size='sm' variant='outline' className="text-xs h-7 px-3 border-esbok-primary text-esbok-primary hover:bg-esbok-primary hover:text-gray-800">Join</Button>
-                        ) : (
-                          <div className="text-gray-400">
-                            <svg width='6' height='10' viewBox='0 0 6 10' fill='none' xmlns='http://www.w3.org/2000/svg'>
-                              <path d='M1 9L5 5L1 1' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' strokeLinejoin='round' />
-                            </svg>
-                          </div>
-                        )}
-                      </div>
+                      )}
                     </div>
-                  </CardContent>
-                </Card>
+                  }
+                  right={
+                    pantry.status === 'nearby' ? (
+                      <Button size='sm' variant='outline' className="text-xs h-7 px-3 border-esbok-primary text-esbok-primary hover:bg-esbok-primary hover:text-gray-800">Join</Button>
+                    ) : (
+                      <div className="text-gray-400">
+                        <svg width='6' height='10' viewBox='0 0 6 10' fill='none' xmlns='http://www.w3.org/2000/svg'>
+                          <path d='M1 9L5 5L1 1' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' strokeLinejoin='round' />
+                        </svg>
+                      </div>
+                    )
+                  }
+                >
+                  <div className="p-3">
+                    <div className="flex items-start justify-between mb-1">
+                      <h3 className="font-semibold text-sm text-gray-800">{pantry.name}</h3>
+                      {pantry.status === 'admin' && (
+                        <Badge variant='secondary' className="text-xs bg-esbok-mint text-gray-700">Admin</Badge>
+                      )}
+                      {pantry.status === 'joined' && (
+                        <Badge variant='secondary' className="text-xs bg-purple-100 text-purple-700">Joined</Badge>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 text-xs text-gray-500 mb-1">
+                      <Apple className="w-3 h-3" />
+                      <span>{pantry.itemCount} items</span>
+                      {pantry.distance && (
+                        <>
+                          <span>•</span>
+                          <MapPin className="w-3 h-3" />
+                          <span>{pantry.distance}</span>
+                        </>
+                      )}
+                    </div>
+                    {pantry.lastContributed && (
+                      <div className="flex items-center gap-1 text-xs text-gray-500">
+                        <Clock className="w-3 h-3" />
+                        <span>Last contributed {pantry.lastContributed}</span>
+                      </div>
+                    )}
+                  </div>
+                </MediaCard>
               ))}
           </div>
 
@@ -123,32 +126,34 @@ export default function PantriesPage() {
           <CardSectionsLayout title="Recently Viewed" className="pb-6">
             <div className="space-y-3">
               {recentlyViewedPantries.map((pantry) => (
-                <Card key={pantry.id} className="border border-esbok-border overflow-hidden">
-                  <CardContent className="p-0">
-                    <div className="flex">
-                      <div className="w-16 h-16 bg-gray-100 flex-shrink-0 flex items-center justify-center">
-                        <img src={pantry.image || '/placeholder.svg'} alt={pantry.name} className="w-full h-full object-cover" />
+                <MediaCard
+                  key={pantry.id}
+                  className="overflow-hidden"
+                  contentClassName="p-0"
+                  left={
+                    <div className="w-16 h-16 bg-gray-100 flex items-center justify-center">
+                      <img src={pantry.image || '/placeholder.svg'} alt={pantry.name} className="w-full h-full object-cover" />
+                    </div>
+                  }
+                  right={
+                    <Button size='sm' variant='outline' className="text-xs h-7 px-3 border-esbok-primary text-esbok-primary hover:bg-esbok-primary hover:text-gray-800">Join</Button>
+                  }
+                >
+                  <div className="p-3">
+                    <h3 className="font-semibold text-sm text-gray-800 mb-1">{pantry.name}</h3>
+                    <div className="flex items-center gap-3 text-xs text-gray-500">
+                      <div className="flex items-center gap-1">
+                        <MapPin className="w-3 h-3" />
+                        <span>{pantry.distance}</span>
                       </div>
-                      <div className="flex-1 p-3">
-                        <h3 className="font-semibold text-sm text-gray-800 mb-1">{pantry.name}</h3>
-                        <div className="flex items-center gap-3 text-xs text-gray-500">
-                          <div className="flex items-center gap-1">
-                            <MapPin className="w-3 h-3" />
-                            <span>{pantry.distance}</span>
-                          </div>
-                          <div className="flex items-center gap-1">
-                            <Apple className="w-3 h-3" />
-                            <span>{pantry.itemCount} items</span>
-                          </div>
-                        </div>
-                        <p className="text-xs text-gray-400 mt-1">Viewed {pantry.lastViewed}</p>
-                      </div>
-                      <div className="flex items-center pr-3">
-                        <Button size='sm' variant='outline' className="text-xs h-7 px-3 border-esbok-primary text-esbok-primary hover:bg-esbok-primary hover:text-gray-800">Join</Button>
+                      <div className="flex items-center gap-1">
+                        <Apple className="w-3 h-3" />
+                        <span>{pantry.itemCount} items</span>
                       </div>
                     </div>
-                  </CardContent>
-                </Card>
+                    <p className="text-xs text-gray-400 mt-1">Viewed {pantry.lastViewed}</p>
+                  </div>
+                </MediaCard>
               ))}
             </div>
           </CardSectionsLayout>

--- a/esbok-client/app/pantries/page.tsx
+++ b/esbok-client/app/pantries/page.tsx
@@ -2,7 +2,6 @@
 import { useState } from 'react';
 import { allPantries, recentlyViewedPantries } from '@/lib/data';
 import { Apple, Plus, MapPin, Heart, Clock } from 'lucide-react';
-import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import PageLayout from '@/components/page-layout';

--- a/esbok-client/components/composite/media-card.tsx
+++ b/esbok-client/components/composite/media-card.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import React from "react";
+
+interface MediaCardProps {
+  /** Element displayed on the left side, e.g. image or icon container */
+  left: React.ReactNode;
+  /** Optional element on the right side, e.g. arrow or action button */
+  right?: React.ReactNode;
+  /** Main content */
+  children: React.ReactNode;
+  /** Additional classes for Card */
+  className?: string;
+  /** Classes for CardContent */
+  contentClassName?: string;
+  /** Classes for inner wrapper */
+  wrapperClassName?: string;
+}
+
+export default function MediaCard({
+  left,
+  right,
+  children,
+  className,
+  contentClassName,
+  wrapperClassName,
+}: MediaCardProps) {
+  return (
+    <Card className={cn("border border-esbok-border overflow-hidden", className)}>
+      <CardContent className={cn("p-4", contentClassName)}>
+        <div className={cn("flex gap-3", wrapperClassName)}>
+          <div className="flex-shrink-0">{left}</div>
+          <div className="flex-1 min-w-0">{children}</div>
+          {right && <div className="flex items-center">{right}</div>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/esbok-client/components/composite/stat-card.tsx
+++ b/esbok-client/components/composite/stat-card.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import React from "react";
+
+interface StatCardProps {
+  icon: React.ReactNode;
+  label: React.ReactNode;
+  value: React.ReactNode;
+  /** Background color utility classes for the icon container. */
+  iconBgClass?: string;
+  /** Size variant. Default is 'lg' */
+  size?: "sm" | "lg";
+  className?: string;
+}
+
+export default function StatCard({
+  icon,
+  label,
+  value,
+  iconBgClass = "bg-esbok-mint",
+  size = "lg",
+  className,
+}: StatCardProps) {
+  const iconSize = size === "sm" ? "w-6 h-6" : "w-8 h-8";
+  const innerIconSize = size === "sm" ? "w-3 h-3" : "w-4 h-4";
+  const padding = size === "sm" ? "p-3" : "p-4";
+  const margin = size === "sm" ? "mb-1" : "mb-2";
+
+  return (
+    <Card className={cn("border border-esbok-border", className)}>
+      <CardContent className={cn(padding, "text-center")}>
+        <div
+          className={cn(
+            iconSize,
+            margin,
+            "mx-auto rounded-full flex items-center justify-center",
+            iconBgClass
+          )}
+        >
+          {/* clone element to apply size */}
+          {React.isValidElement(icon)
+            ? React.cloneElement(icon as React.ReactElement, {
+                className: cn(innerIconSize, icon.props.className),
+              })
+            : icon}
+        </div>
+        <p className="text-xs text-gray-600">{label}</p>
+        <p className="text-lg font-bold text-gray-800">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/esbok-client/components/composite/stat-card.tsx
+++ b/esbok-client/components/composite/stat-card.tsx
@@ -1,15 +1,53 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
 import React from "react";
 
-interface StatCardProps {
+const statCardVariants = cva("text-center", {
+  variants: {
+    size: {
+      sm: "p-3",
+      lg: "p-4",
+    },
+  },
+  defaultVariants: {
+    size: "lg",
+  },
+});
+
+const iconContainerVariants = cva(
+  "mx-auto rounded-full flex items-center justify-center",
+  {
+    variants: {
+      size: {
+        sm: "w-6 h-6 mb-1",
+        lg: "w-8 h-8 mb-2",
+      },
+    },
+    defaultVariants: {
+      size: "lg",
+    },
+  }
+);
+
+const iconVariants = cva("", {
+  variants: {
+    size: {
+      sm: "w-3 h-3",
+      lg: "w-4 h-4",
+    },
+  },
+  defaultVariants: {
+    size: "lg",
+  },
+});
+
+interface StatCardProps extends VariantProps<typeof statCardVariants> {
   icon: React.ReactNode;
   label: React.ReactNode;
   value: React.ReactNode;
   /** Background color utility classes for the icon container. */
   iconBgClass?: string;
-  /** Size variant. Default is 'lg' */
-  size?: "sm" | "lg";
   className?: string;
 }
 
@@ -18,29 +56,16 @@ export default function StatCard({
   label,
   value,
   iconBgClass = "bg-esbok-mint",
-  size = "lg",
+  size,
   className,
 }: StatCardProps) {
-  const iconSize = size === "sm" ? "w-6 h-6" : "w-8 h-8";
-  const innerIconSize = size === "sm" ? "w-3 h-3" : "w-4 h-4";
-  const padding = size === "sm" ? "p-3" : "p-4";
-  const margin = size === "sm" ? "mb-1" : "mb-2";
-
   return (
     <Card className={cn("border border-esbok-border", className)}>
-      <CardContent className={cn(padding, "text-center")}>
-        <div
-          className={cn(
-            iconSize,
-            margin,
-            "mx-auto rounded-full flex items-center justify-center",
-            iconBgClass
-          )}
-        >
-          {/* clone element to apply size */}
+      <CardContent className={cn(statCardVariants({ size }))}>
+        <div className={cn(iconContainerVariants({ size }), iconBgClass)}>
           {React.isValidElement(icon)
             ? React.cloneElement(icon as React.ReactElement, {
-                className: cn(innerIconSize, icon.props.className),
+                className: cn(iconVariants({ size }), icon.props.className),
               })
             : icon}
         </div>


### PR DESCRIPTION
## Summary
- factor repeated card layouts into `StatCard` and `MediaCard`
- refactor pages to use the new components

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d27915f083219220c6ea93bb2e7c