### PR TITLE
Add sign-in/up pages with Google SSO

### DIFF
--- a/esbok-client/app/auth/actions.ts
+++ b/esbok-client/app/auth/actions.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { redirect } from "next/navigation";
+
+export type AuthState = {
+  error?: string;
+};
+export async function signIn(_: AuthState | undefined, formData: FormData) {
+  const supabase = await createClient();
+  const email = String(formData.get("email"));
+  const password = String(formData.get("password"));
+
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) {
+    return { error: error.message };
+  }
+
+  redirect("/home");
+}
+
+export async function signUp(_: AuthState | undefined, formData: FormData) {
+  const supabase = await createClient();
+  const email = String(formData.get("email"));
+  const password = String(formData.get("password"));
+
+  const { error } = await supabase.auth.signUp({ email, password });
+  if (error) {
+    return { error: error.message };
+  }
+
+  redirect("/home");
+}
+
+export async function signOut() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect("/sign-in");
+}

--- a/esbok-client/app/profile/page.tsx
+++ b/esbok-client/app/profile/page.tsx
@@ -1,6 +1,7 @@
 import BottomNav from "@/components/bottom-nav";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
+import { signOut } from "../auth/actions";
 
 export default function ProfilePage() {
   return (
@@ -64,28 +65,30 @@ export default function ProfilePage() {
               />
             </svg>
           </Button>
-          <Button
-            variant="ghost"
-            className="w-full flex items-center justify-between border border-esbok-border rounded-lg px-4 py-3 text-gray-800"
-          >
-            <span>Log Out</span>
-            <svg
-              width="6"
-              height="10"
-              viewBox="0 0 6 10"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              className="text-gray-400"
+          <form action={signOut} className="w-full">
+            <Button
+              variant="ghost"
+              className="w-full flex items-center justify-between border border-esbok-border rounded-lg px-4 py-3 text-gray-800"
             >
-              <path
-                d="M1 9L5 5L1 1"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </Button>
+              <span>Log Out</span>
+              <svg
+                width="6"
+                height="10"
+                viewBox="0 0 6 10"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="text-gray-400"
+              >
+                <path
+                  d="M1 9L5 5L1 1"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </Button>
+          </form>
         </div>
       </div>
       <BottomNav />

--- a/esbok-client/app/sign-in/page.tsx
+++ b/esbok-client/app/sign-in/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useFormState } from "react-dom";
+import { signIn } from "../auth/actions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import Link from "next/link";
+import { createClient } from "@/utils/supabase/client";
+
+export default function SignInPage() {
+  const supabase = createClient();
+  const [state, formAction] = useFormState(signIn, { error: null });
+
+  const handleGoogle = async () => {
+    await supabase.auth.signInWithOAuth({ provider: "google" });
+  };
+
+  return (
+    <div className="max-w-sm mx-auto flex flex-col justify-center min-h-screen p-5 space-y-4">
+      <h1 className="text-xl font-bold text-center">Sign In</h1>
+      {state?.error && <p className="text-sm text-red-500 text-center">{state.error}</p>}
+      <form action={formAction} className="space-y-3">
+        <div>
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" name="email" type="email" required />
+        </div>
+        <div>
+          <Label htmlFor="password">Password</Label>
+          <Input id="password" name="password" type="password" required />
+        </div>
+        <Button type="submit" className="w-full">Sign In</Button>
+      </form>
+      <Button variant="outline" className="w-full" onClick={handleGoogle}>
+        Continue with Google
+      </Button>
+      <p className="text-sm text-center">
+        Don&apos;t have an account?{' '}
+        <Link href="/sign-up" className="underline">
+          Sign up
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/esbok-client/app/sign-up/page.tsx
+++ b/esbok-client/app/sign-up/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useFormState } from "react-dom";
+import { signUp } from "../auth/actions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import Link from "next/link";
+import { createClient } from "@/utils/supabase/client";
+
+export default function SignUpPage() {
+  const supabase = createClient();
+  const [state, formAction] = useFormState(signUp, { error: null });
+
+  const handleGoogle = async () => {
+    await supabase.auth.signInWithOAuth({ provider: "google" });
+  };
+
+  return (
+    <div className="max-w-sm mx-auto flex flex-col justify-center min-h-screen p-5 space-y-4">
+      <h1 className="text-xl font-bold text-center">Sign Up</h1>
+      {state?.error && <p className="text-sm text-red-500 text-center">{state.error}</p>}
+      <form action={formAction} className="space-y-3">
+        <div>
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" name="email" type="email" required />
+        </div>
+        <div>
+          <Label htmlFor="password">Password</Label>
+          <Input id="password" name="password" type="password" required />
+        </div>
+        <Button type="submit" className="w-full">Sign Up</Button>
+      </form>
+      <Button variant="outline" className="w-full" onClick={handleGoogle}>
+        Continue with Google
+      </Button>
+      <p className="text-sm text-center">
+        Already have an account?{' '}
+        <Link href="/sign-in" className="underline">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement auth server actions for sign in, sign up and sign out
- add sign in and sign up pages including Google OAuth
- connect log out button on profile page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_6844f43e8f6c8321a7e543f188b1bf1a