### PR TITLE
Implement pantry and food item paginated actions

### DIFF
--- a/esbok-client/app/actions/food_item/getPantryFoodItemsPaginated.ts
+++ b/esbok-client/app/actions/food_item/getPantryFoodItemsPaginated.ts
@@ -1,0 +1,48 @@
+"use server";
+import { Database } from "@/types/supabase";
+import { createClient } from "@/utils/supabase/server";
+
+export type FoodItem = Database["public"]["Tables"]["food_item"]["Row"];
+export type Pantry = Database["public"]["Tables"]["pantry"]["Row"];
+
+interface Options {
+  pantryId: Pantry["id"];
+  page?: number;
+  limit?: number;
+  tagIds?: number[];
+}
+
+/**
+ * Fetch food items for a pantry with optional tag filters.
+ * @param options Query options including pagination and tag filters.
+ * @throws Will throw an error if the fetch fails.
+ * @returns Array of FoodItem objects.
+ */
+export async function getPantryFoodItemsPaginated({
+  pantryId,
+  page = 1,
+  limit = 10,
+  tagIds,
+}: Options): Promise<FoodItem[]> {
+  const supabase = await createClient();
+
+  let query = supabase
+    .from("food_item")
+    .select("*, food_item_food_tag!inner(food_tag_id)")
+    .eq("pantry_id", pantryId);
+
+  if (tagIds && tagIds.length > 0) {
+    query = query.in("food_item_food_tag.food_tag_id", tagIds);
+  }
+
+  const from = (page - 1) * limit;
+  const { data, error } = await query
+    .order("id", { ascending: false })
+    .range(from, from + limit - 1);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+}

--- a/esbok-client/app/actions/pantry/getPantriesPaginated.ts
+++ b/esbok-client/app/actions/pantry/getPantriesPaginated.ts
@@ -1,0 +1,34 @@
+"use server";
+import { Database } from "@/types/supabase";
+import { createClient } from "@/utils/supabase/server";
+
+export type Pantry = Database["public"]["Tables"]["pantry"]["Row"];
+
+/**
+ * Fetch pantries with pagination support.
+ * @param page Page number starting from 1.
+ * @param limit Number of records per page.
+ * @throws Will throw an error if the fetch fails.
+ * @returns Array of Pantry objects.
+ */
+export async function getPantriesPaginated({
+  page = 1,
+  limit = 10,
+}: {
+  page?: number;
+  limit?: number;
+}): Promise<Pantry[]> {
+  const supabase = await createClient();
+  const from = (page - 1) * limit;
+  const { data, error } = await supabase
+    .from("pantry")
+    .select("*")
+    .order("id", { ascending: true })
+    .range(from, from + limit - 1);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+}

--- a/esbok-client/app/actions/pantry/getPantry.ts
+++ b/esbok-client/app/actions/pantry/getPantry.ts
@@ -1,0 +1,29 @@
+"use server";
+import { Database } from "@/types/supabase";
+import { createClient } from "@/utils/supabase/server";
+
+// 1) Alias your row & insert shapes
+export type Pantry = Database["public"]["Tables"]["pantry"]["Row"];
+
+/**
+ * Get a pantry by its ID.
+ * @param id The ID of the pantry to retrieve.
+ * @throws Will throw an error if the fetch fails.
+ * @returns Pantry object or null if not found.
+ */
+export async function getPantry(
+  id: Pantry["id"]
+): Promise<Pantry | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("pantry")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- rename pantry and food item infinite actions to paginated
- allow page based pagination instead of range index

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684773af41b08321b9add1e4b99327ca